### PR TITLE
Made a few goog changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 BrayanBot Organization & its members
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Modules/Handlers/Database.js
+++ b/Modules/Handlers/Database.js
@@ -43,8 +43,8 @@ module.exports = {
         } else if (db && tableName && values) {
             try {
                 db.prepare(`CREATE TABLE IF NOT EXISTS ${tableName} (${values})`).run();
-                if (config.Settings.DevMode)
-                    Utils.logInfo(`${chalk.bold(tableName)} Table Ready. (${chalk.bold(db.name.replace("Database/", ""))})`);
+                if (config.Settings.DbReady)
+                    Utils.logTable(`${chalk.bold(tableName)} Table Ready. (${chalk.bold(db.name.replace("Database/", ""))})`);
             } catch (err) {
                 Utils.logWarning(`An error occured while setting up database. (${tableName})`);
                 reject(err);

--- a/Modules/Utils.js
+++ b/Modules/Utils.js
@@ -11,6 +11,7 @@ module.exports = {
     logWarning: (...text) => console.log(chalk.hex("#edd100").bold("[WARN] ") + text),
     logError: (...text) => console.log(chalk.hex("#ff0800").bold("[ERROR] ") + text),
     logInfo: (...text) => console.log(chalk.hex("#57ff6b").bold("[INFO] ") + text),
+    logTable: (...text) => console.log(chalk.hex("#57ff6b").bold("[TABLE] ") + text),
     logDebug: (...text) => console.log(chalk.hex("#ffff00").bold("[DEBUG] ") + text),
     /** @param {Array} array*/
     getRandom: (array) => {

--- a/example.config.yml
+++ b/example.config.yml
@@ -3,9 +3,13 @@ Settings:
   Prefix: "-"
   Storage: "database.db"
   # Enabling DevMode will reset all addon configurations.
-  DevMode: false 
+  DevMode: false
+  # Enabling DbReady will show table ready messages on startup.
+  DbReady: true
+  # Enabling DelError will delete errors.txt on startup.
+  DelError: false
   # Verbose mode enables additional debug messages to be shown on the startup log.
-  Verbose: true 
+  Verbose: true
 
 Embeds:
   Color: "2f3136"

--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ installNodeModules().then(async () => {
     for (let index = 0; index < handlers.length; index++)
         await require(`./Modules/Handlers/${handlers[index]}`).init()
 
+    if (client.config.Settings.DelError) {
+        if (fs.existsSync("errors.txt")) fs.unlinkSync("errors.txt");
+    }
+
     if (client.config.Settings.Token)
         client.login(client.config.Settings.Token);
     else return Utils.logError("An invalid token was provided.");


### PR DESCRIPTION
### Added Config Options (Settings)
- [+] `DbReady` - Enabling this would show `[TABLE]` ready msgs on startup. No need to keep dev mode on for this msg.
- [+] `DelError` - Enabling this would delete `errors.txt` on every startup (If it exists). Good for addon devs ✌

### Changes to Log option
> _Changes are made in `Utils.js` and `Database.js`_
- [+] `Utils.logTable()` - Instead of `[INFO] xyz Table Ready. (xyz.db)` it will show `[TABLE] xyz Table Ready. (xyz.db)`